### PR TITLE
Adding support for k8s_nodes stockpile module

### DIFF
--- a/transcribe/schema/k8s_nodes.yml
+++ b/transcribe/schema/k8s_nodes.yml
@@ -1,0 +1,16 @@
+scribe_uuid:
+  type: string
+  required: True
+host:
+  type: string
+  required: True
+module:
+  type: string
+  required: True
+source_type:
+  type: string
+  allowed: ['stockpile','foo']
+  required: True
+value:
+  type: dict
+  required: False

--- a/transcribe/scribe_modules/k8s_nodes.py
+++ b/transcribe/scribe_modules/k8s_nodes.py
@@ -1,0 +1,30 @@
+from . import ScribeModuleBaseClass
+from . lib.util import format_url
+
+import re as _re
+import sys
+
+
+class K8s_nodes(ScribeModuleBaseClass):
+
+    def __init__(self, input_dict=None, module_name=None, host_name=None,
+                 input_type=None, scribe_uuid=None):
+        ScribeModuleBaseClass.__init__(self, module_name=module_name,
+                                       input_dict=input_dict,
+                                       host_name=host_name,
+                                       input_type=input_type,
+                                       scribe_uuid=scribe_uuid)
+        if input_dict:
+            self.value = self._parse(input_dict)
+
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            yield attr, value
+
+    def _parse(self, nodes_full):
+        # Currently no work needs to be done to node info so we
+        # just confirm that it has data and move on
+        if len(nodes_full) <= 1:
+            print("Error occured in processing k8s Nodes data")
+            sys.exit(1)
+        return nodes_full


### PR DESCRIPTION
example output:
```
{
    "module": "k8s_nodes",
    "source_type": "stockpile",
    "host": "localhost",
    "scribe_uuid": "b415ff11-f8ab-40b0-9aa2-f6acda6b9e15",
    "value": {
        "apiVersion": "v1",
        "kind": "Node",
        "metadata": {
            "annotations": {
                "kubeadm.alpha.kubernetes.io/cri-socket": "/var/run/dockershim.sock",
                "node.alpha.kubernetes.io/ttl": "0",
                "volumes.kubernetes.io/controller-managed-attach-detach": "true"
            },
            "creationTimestamp": "2019-08-16T16:01:16Z",
            "labels": {
                "beta.kubernetes.io/arch": "amd64",
                "beta.kubernetes.io/os": "linux",
                "kubernetes.io/arch": "amd64",
                "kubernetes.io/hostname": "minikube",
                "kubernetes.io/os": "linux",
                "node-role.kubernetes.io/master": ""
            },
            "name": "minikube",
            "resourceVersion": "4742682",
            "selfLink": "/api/v1/nodes/minikube",
            "uid": "8d86205e-18d0-4439-b433-507ac22c850e"
        },
        "spec": {},
        "status": {
            "addresses": [
                {
                    "address": "192.168.124.229",
                    "type": "InternalIP"
                },
                {
                    "address": "minikube",
                    "type": "Hostname"
                }
            ],
            "allocatable": {
                "cpu": "2",
                "ephemeral-storage": "15625027559",
                "hugepages-2Mi": "0",
                "memory": "3743084Ki",
                "pods": "110"
            },
            "capacity": {
                "cpu": "2",
                "ephemeral-storage": "16954240Ki",
                "hugepages-2Mi": "0",
                "memory": "3845484Ki",
                "pods": "110"
            },
            "conditions": [
                {
                    "lastHeartbeatTime": "2019-10-04T14:25:09Z",
                    "lastTransitionTime": "2019-08-16T16:01:12Z",
                    "message": "kubelet has sufficient memory available",
                    "reason": "KubeletHasSufficientMemory",
                    "status": "False",
                    "type": "MemoryPressure"
                },
                {
                    "lastHeartbeatTime": "2019-10-04T14:25:09Z",
                    "lastTransitionTime": "2019-10-01T12:57:07Z",
                    "message": "kubelet has no disk pressure",
                    "reason": "KubeletHasNoDiskPressure",
                    "status": "False",
                    "type": "DiskPressure"
                },
                {
                    "lastHeartbeatTime": "2019-10-04T14:25:09Z",
                    "lastTransitionTime": "2019-08-16T16:01:12Z",
                    "message": "kubelet has sufficient PID available",
                    "reason": "KubeletHasSufficientPID",
                    "status": "False",
                    "type": "PIDPressure"
                },
                {
                    "lastHeartbeatTime": "2019-10-04T14:25:09Z",
                    "lastTransitionTime": "2019-08-16T16:01:12Z",
                    "message": "kubelet is posting ready status",
                    "reason": "KubeletReady",
                    "status": "True",
                    "type": "Ready"
                }
            ],
            "daemonEndpoints": {
                "kubeletEndpoint": {
                    "Port": 10250
                }
            },
            "images": [
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:5210a3123ea254f853a983dcc3118d398188fd2d03c8954d88f14b698a0db4eb"
                    ],
                    "sizeBytes": 1018035643
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:c6c4d56a541128f1a5d14e55c3699fc45e6f0960d44b29591bc59a948d796640"
                    ],
                    "sizeBytes": 1018035582
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:885cc6333ee136e1583e4f70f857e15ac905a7317509c44a4538de336bedfb66",
                        "quay.io/cloud-bulldozer/backpack:master"
                    ],
                    "sizeBytes": 1018035338
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:244bddc90714e5aa93ddc4bd39e70b03fad463ca82a1764409499e31453db0a8"
                    ],
                    "sizeBytes": 1018035301
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:8ef4452e025469c9c31b990d9a4f1087927b1f20ecf9fe42844e76e48212ee8b"
                    ],
                    "sizeBytes": 1018033788
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:1629f1d6bb258c7a004b59bebc294532989297da0d64c060520f4f7f7738dcea"
                    ],
                    "sizeBytes": 1018033476
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:eb5f276019fb85a3edc94e1786deec88de552e712eec6a00598a3417c171a4f5"
                    ],
                    "sizeBytes": 1018023684
                },
                {
                    "names": [
                        "quay.io/cloud-bulldozer/backpack@sha256:2a4ba04f358831b1c1dede5739b838365227163a18c1547fa4dd701bb9900f78"
                    ],
                    "sizeBytes": 1018023347
                },
                {
                    "names": [
                        "k8s.gcr.io/etcd@sha256:17da501f5d2a675be46040422a27b7cc21b8a43895ac998b171db1c346f361f7",
                        "k8s.gcr.io/etcd:3.3.10"
                    ],
                    "sizeBytes": 258116302
                },
                {
                    "names": [
                        "k8s.gcr.io/kube-apiserver@sha256:5fae387bacf1def6c3915b4a3035cf8c8a4d06158b2e676721776d3d4afc05a2",
                        "k8s.gcr.io/kube-apiserver:v1.15.2"
                    ],
                    "sizeBytes": 206823358
                },
                {
                    "names": [
                        "k8s.gcr.io/kube-controller-manager@sha256:7d3fc48cf83aa0a7b8f129fa4255bb5530908e1a5b194be269ea8329b48e9598",
                        "k8s.gcr.io/kube-controller-manager:v1.15.2"
                    ],
                    "sizeBytes": 158718526
                },
                {
                    "names": [
                        "k8s.gcr.io/kube-addon-manager:v9.0"
                    ],
                    "sizeBytes": 83077558
                },
                {
                    "names": [
                        "k8s.gcr.io/kube-proxy@sha256:626f983f25f8b7799ca7ab001fd0985a72c2643c0acb877d2888c0aa4fcbdf56",
                        "k8s.gcr.io/kube-proxy:v1.15.2"
                    ],
                    "sizeBytes": 82408284
                },
                {
                    "names": [
                        "k8s.gcr.io/kube-scheduler@sha256:8fd3c3251f07234a234469e201900e4274726f1fe0d5dc6fb7da911f1c851a1a",
                        "k8s.gcr.io/kube-scheduler:v1.15.2"
                    ],
                    "sizeBytes": 81107582
                },
                {
                    "names": [
                        "gcr.io/k8s-minikube/storage-provisioner:v1.8.1"
                    ],
                    "sizeBytes": 80815640
                },
                {
                    "names": [
                        "k8s.gcr.io/coredns@sha256:02382353821b12c21b062c59184e227e001079bb13ebd01f9d3270ba0fcbf1e4",
                        "k8s.gcr.io/coredns:1.3.1"
                    ],
                    "sizeBytes": 40303560
                },
                {
                    "names": [
                        "k8s.gcr.io/pause@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea",
                        "k8s.gcr.io/pause:3.1"
                    ],
                    "sizeBytes": 742472
                }
            ],
            "nodeInfo": {
                "architecture": "amd64",
                "bootID": "818965eb-43f1-4f4f-bf62-8beb7301c96d",
                "containerRuntimeVersion": "docker://18.9.8",
                "kernelVersion": "4.15.0",
                "kubeProxyVersion": "v1.15.2",
                "kubeletVersion": "v1.15.2",
                "machineID": "6872d7e3b4d04b0da6bb752032d2a12a",
                "operatingSystem": "linux",
                "osImage": "Buildroot 2018.05.3",
                "systemUUID": "6872D7E3-B4D0-4B0D-A6BB-752032D2A12A"
            }
        }
    }
}
```