### PR TITLE
Adding support for k8s Pods module

### DIFF
--- a/transcribe/schema/k8s_pods.yml
+++ b/transcribe/schema/k8s_pods.yml
@@ -1,0 +1,16 @@
+scribe_uuid:
+  type: string
+  required: True
+host:
+  type: string
+  required: True
+module:
+  type: string
+  required: True
+source_type:
+  type: string
+  allowed: ['stockpile','foo']
+  required: True
+value:
+  type: dict
+  required: False

--- a/transcribe/scribe_modules/k8s_pods.py
+++ b/transcribe/scribe_modules/k8s_pods.py
@@ -1,0 +1,30 @@
+from . import ScribeModuleBaseClass
+from . lib.util import format_url
+
+import re as _re
+import sys
+
+
+class K8s_pods(ScribeModuleBaseClass):
+
+    def __init__(self, input_dict=None, module_name=None, host_name=None,
+                 input_type=None, scribe_uuid=None):
+        ScribeModuleBaseClass.__init__(self, module_name=module_name,
+                                       input_dict=input_dict,
+                                       host_name=host_name,
+                                       input_type=input_type,
+                                       scribe_uuid=scribe_uuid)
+        if input_dict:
+            self.value = self._parse(input_dict)
+
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            yield attr, value
+
+    def _parse(self, items_full):
+        # Currently no work needs to be done to this info so we
+        # just confirm that it has data and move on
+        if len(items_full) <= 1:
+            print("Error occured in processing k8s Pods data")
+            sys.exit(1)
+        return items_full


### PR DESCRIPTION
Example output:
```
{
    "module": "k8s_pods",
    "source_type": "stockpile",
    "host": "localhost",
    "scribe_uuid": "6f91e6a9-cc77-4e7a-b508-c23b08527247",
    "value": {
        "apiVersion": "v1",
        "kind": "Pod",
        "metadata": {
            "annotations": {
                "kubernetes.io/config.hash": "abfcb4f52e957b11256c1f6841d49700",
                "kubernetes.io/config.mirror": "abfcb4f52e957b11256c1f6841d49700",
                "kubernetes.io/config.seen": "2019-08-16T16:00:49.402092608Z",
                "kubernetes.io/config.source": "file"
            },
            "creationTimestamp": "2019-08-16T16:02:24Z",
            "labels": {
                "component": "kube-scheduler",
                "tier": "control-plane"
            },
            "name": "kube-scheduler-minikube",
            "namespace": "kube-system",
            "resourceVersion": "3579991",
            "selfLink": "/api/v1/namespaces/kube-system/pods/kube-scheduler-minikube",
            "uid": "0d67bf9d-55ed-475d-80f0-9fafc3fae98a"
        },
        "spec": {
            "containers": [
                {
                    "command": [
                        "kube-scheduler",
                        "--bind-address=127.0.0.1",
                        "--kubeconfig=/etc/kubernetes/scheduler.conf",
                        "--leader-elect=true"
                    ],
                    "image": "k8s.gcr.io/kube-scheduler:v1.15.2",
                    "imagePullPolicy": "IfNotPresent",
                    "livenessProbe": {
                        "failureThreshold": 8,
                        "httpGet": {
                            "host": "127.0.0.1",
                            "path": "/healthz",
                            "port": 10251,
                            "scheme": "HTTP"
                        },
                        "initialDelaySeconds": 15,
                        "periodSeconds": 10,
                        "successThreshold": 1,
                        "timeoutSeconds": 15
                    },
                    "name": "kube-scheduler",
                    "resources": {
                        "requests": {
                            "cpu": "100m"
                        }
                    },
                    "terminationMessagePath": "/dev/termination-log",
                    "terminationMessagePolicy": "File",
                    "volumeMounts": [
                        {
                            "mountPath": "/etc/kubernetes/scheduler.conf",
                            "name": "kubeconfig",
                            "readOnly": true
                        }
                    ]
                }
            ],
            "dnsPolicy": "ClusterFirst",
            "enableServiceLinks": true,
            "hostNetwork": true,
            "nodeName": "minikube",
            "priority": 2000000000,
            "priorityClassName": "system-cluster-critical",
            "restartPolicy": "Always",
            "schedulerName": "default-scheduler",
            "securityContext": {},
            "terminationGracePeriodSeconds": 30,
            "tolerations": [
                {
                    "effect": "NoExecute",
                    "operator": "Exists"
                }
            ],
            "volumes": [
                {
                    "hostPath": {
                        "path": "/etc/kubernetes/scheduler.conf",
                        "type": "FileOrCreate"
                    },
                    "name": "kubeconfig"
                }
            ]
        },
        "status": {
            "conditions": [
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:04Z",
                    "status": "True",
                    "type": "Initialized"
                },
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:05Z",
                    "status": "True",
                    "type": "Ready"
                },
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:05Z",
                    "status": "True",
                    "type": "ContainersReady"
                },
                {
                    "lastProbeTime": null,
                    "lastTransitionTime": "2019-09-23T13:48:04Z",
                    "status": "True",
                    "type": "PodScheduled"
                }
            ],
            "containerStatuses": [
                {
                    "containerID": "docker://1d724b769b33a845ae1370964683b969f8bf3a98f47f37559c19bbb19b97b64a",
                    "image": "k8s.gcr.io/kube-scheduler:v1.15.2",
                    "imageID": "docker-pullable://k8s.gcr.io/kube-scheduler@sha256:8fd3c3251f07234a234469e201900e4274726f1fe0d5dc6fb7da911f1c851a1a",
                    "lastState": {
                        "terminated": {
                            "containerID": "docker://23fcc7d561de65b70dbb75097083c3fb83d6fb10bfbbb27905b4c3dccb8f2692",
                            "exitCode": 255,
                            "finishedAt": "2019-09-23T13:47:33Z",
                            "reason": "Error",
                            "startedAt": "2019-09-20T12:33:51Z"
                        }
                    },
                    "name": "kube-scheduler",
                    "ready": true,
                    "restartCount": 67,
                    "state": {
                        "running": {
                            "startedAt": "2019-09-23T13:48:05Z"
                        }
                    }
                }
            ],
            "hostIP": "192.168.124.229",
            "phase": "Running",
            "podIP": "192.168.124.229",
            "qosClass": "Burstable",
            "startTime": "2019-09-23T13:48:04Z"
        }
    }
}
```