### PR TITLE
fixed function name for k8s nodes module

### DIFF
--- a/transcribe/scribe_modules/k8s_nodes.py
+++ b/transcribe/scribe_modules/k8s_nodes.py
@@ -11,7 +11,7 @@ class K8s_nodes(ScribeModuleBaseClass):
                                        input_type=input_type,
                                        scribe_uuid=scribe_uuid)
 
-    def _parse(self):
+    def parse(self):
         nodes_full = self._input_dict
         # Flatten some of the dictionaries to lists
         validate_length(len(nodes_full), self.module)


### PR DESCRIPTION
Following #22 , all modules are updated to use parse function, but for nodes somehow this got missed, so fixing it