### PR TITLE
Remove managedFields

### DIFF
--- a/transcribe/scribe_modules/k8s_configmaps.py
+++ b/transcribe/scribe_modules/k8s_configmaps.py
@@ -1,5 +1,6 @@
 from . import ScribeModuleBaseClass
 from . lib.util import to_list, validate_length
+from . lib.k8s_util import remove_managed_fields
 
 class K8s_configmaps(ScribeModuleBaseClass):
 
@@ -25,6 +26,7 @@ class K8s_configmaps(ScribeModuleBaseClass):
             tmp_list = []
             tmp_list.append(items_full["data"])
             items_full["data"] = tmp_list
+        remove_managed_fields(items_full)
         output_dict = self._dict
         output_dict['value'] = items_full
         yield output_dict

--- a/transcribe/scribe_modules/k8s_namespaces.py
+++ b/transcribe/scribe_modules/k8s_namespaces.py
@@ -1,6 +1,7 @@
 import json
 
 from . import ScribeModuleBaseClass
+from . lib.k8s_util import remove_managed_fields 
 from transcribe.scribe_modules.lib import util
 
 
@@ -15,5 +16,7 @@ class K8s_namespaces(ScribeModuleBaseClass):
                                        scribe_uuid=scribe_uuid)
 
     def parse(self):
+        remove_managed_fields(self._input_dict)
         self._dict['value'] = util.fix_nested_dict(self._input_dict)
         yield self._dict
+

--- a/transcribe/scribe_modules/k8s_nodes.py
+++ b/transcribe/scribe_modules/k8s_nodes.py
@@ -1,5 +1,6 @@
 from . import ScribeModuleBaseClass
 from . lib.util import to_list, validate_length
+from . lib.k8s_util import remove_managed_fields
 
 class K8s_nodes(ScribeModuleBaseClass):
 
@@ -19,5 +20,6 @@ class K8s_nodes(ScribeModuleBaseClass):
         nodes_full = to_list("metadata","annotations",nodes_full)
         nodes_full = to_list("metadata","labels",nodes_full)
         output_dict = self._dict
+        remove_managed_fields(nodes_full)
         output_dict['value'] = nodes_full
         yield output_dict

--- a/transcribe/scribe_modules/k8s_pods.py
+++ b/transcribe/scribe_modules/k8s_pods.py
@@ -1,5 +1,6 @@
 from . import ScribeModuleBaseClass
 from . lib.util import validate_length
+from . lib.k8s_util import remove_managed_fields
 
 class K8s_pods(ScribeModuleBaseClass):
 
@@ -31,6 +32,7 @@ class K8s_pods(ScribeModuleBaseClass):
         items_full = to_list("metadata","labels",items_full)
         items_full = to_list("spec","securityContext",items_full)
         items_full = to_list("spec","nodeSelector",items_full)
+        remove_managed_fields(items_full)
         output_dict = self._dict
         output_dict['value'] = items_full
         yield output_dict

--- a/transcribe/scribe_modules/lib/k8s_util.py
+++ b/transcribe/scribe_modules/lib/k8s_util.py
@@ -1,0 +1,4 @@
+
+def remove_managed_fields(d):
+    if "metadata" in d:
+        d["metadata"].pop("managedFields", None)


### PR DESCRIPTION
We have parsing issues due to the new (and useless here) field managedFields.

i.e.
```json
{"apiVersion":"v1","kind":"Namespace","metadata": {"annotations": {"openshift.io/description":"Multus network plugin components","openshift.io/node-selector":"","openshift.io/sa.scc.mcs":"s0:c13,c7","openshift.io/sa.scc.supplemental-groups":"1000170000/10000","openshift.io/sa.scc.uid-range":"1000170000/10000"},"creationTimestamp":"2020-07-15T09:03:35Z","labels": {"name":"openshift-multus","olm.operatorgroup.uid/876cb22f-326a-41c2-8918-d9f5da7a40c1":"","openshift.io/cluster-monitoring":"true","openshift.io/run-level":"0"},"managedFields": [{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1": {"f:metadata": {"f:annotations": {".": {},"f:openshift.io/description": {},"f:openshift.io/node-selector": {}},"f:labels": {".": {},"f:name": {},"f:openshift.io/cluster-monitoring": {},"f:openshift.io/run-level": {}},"f:ownerReferences": {".": {},"k:{"uid":"41257bec-2ded-466b-be18-ffd80555faaa"}": {".": {},"f:apiVersion": {},"f:blockOwnerDeletion": {},"f:controller": {},"f:kind": {},"f:name": {},"f:uid": {}}}},"f:status": {"f:phase": {}}},"manager":"cluster-network-operator","operation":"Update","time":"2020-07-15T09:03:35Z"}, {"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1": {"f:metadata": {"f:annotations": {"f:openshift.io/sa.scc.mcs": {},"f:openshift.io/sa.scc.supplemental-groups": {},"f:openshift.io/sa.scc.uid-range": {}}}},"manager":"cluster-policy-controller","operation":"Update","time":"2020-07-15T09:07:52Z"}, {"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1": {"f:metadata": {"f:labels": {"f:olm.operatorgroup.uid/876cb22f-326a-41c2-8918-d9f5da7a40c1": {}}}},"manager":"olm","operation":"Update","time":"2020-07-15T09:23:10Z"}],"name":"openshift-multus","ownerReferences": [{"apiVersion":"operator.openshift.io/v1","blockOwnerDeletion": true,"controller": true,"kind":"Network","name":"cluster","uid":"41257bec-2ded-466b-be18-ffd80555faaa"}],"resourceVersion":"25067","selfLink":"/api/v1/namespaces/openshift-multus","uid":"c446edb5-6030-4bb2-af60-610a1002ce17"},"spec": {"finalizers": ["kubernetes"]},"status": {"phase":"Active"}}
```

Threw the traceback:

```
Traceback (most recent call last):
  File "/home/rsevilla/.virtualenvs/scribe/bin/scribe", line 10, in <module>
    sys.exit(main())
  File "/home/rsevilla/labs/cloud-bulldozer/scribe/scribe.py", line 30, in main
    for scribed_doc in transcribe(input_data_path, scribe_type):
  File "/home/rsevilla/labs/cloud-bulldozer/scribe/transcribe/render.py", line 46, in transcribe
    _scribe_uuid)
  File "/home/rsevilla/labs/cloud-bulldozer/scribe/transcribe/render.py", line 22, in _create_module_yield_doc
    for document in scribe_module_instance.parse():
  File "/home/rsevilla/labs/cloud-bulldozer/scribe/transcribe/scribe_modules/k8s_namespaces.py", line 31, in parse
    new_dict = json.loads(new_items)
  File "/usr/lib64/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting ':' delimiter: line 1 column 853 (char 852)
```
Where character 853 belongs to a field from the managedFields dict.

Let's get rid of managedFields.
