### PR TITLE
Stop indexing nested objects

### DIFF
--- a/transcribe/scribe_modules/k8s_configmaps.py
+++ b/transcribe/scribe_modules/k8s_configmaps.py
@@ -1,6 +1,7 @@
 from . import ScribeModuleBaseClass
-from . lib.util import to_list, validate_length
-from . lib.k8s_util import remove_managed_fields
+from . lib.util import dict_to_list, validate_length
+from . lib.k8s_util import remove_unused_fields
+
 
 class K8s_configmaps(ScribeModuleBaseClass):
 
@@ -16,17 +17,11 @@ class K8s_configmaps(ScribeModuleBaseClass):
         items_full = self._input_dict
         validate_length(len(items_full), self.module)
         # Flatten some of the dictionaries to lists
-        items_full = to_list("metadata","annotations",items_full)
-        items_full = to_list("metadata","labels",items_full)
+        remove_unused_fields(items_full)
+        items_full["metadata"]["annotations"] = dict_to_list(items_full, "metadata", "annotations")
+        items_full["metadata"]["labels"] = dict_to_list(items_full, "metadata", "labels")
         if "data" in items_full.keys():
-            # If . in key name replace it with with an _
-            for my_key in items_full["data"].keys():
-                if "." in my_key:
-                    items_full["data"][my_key.replace('.','_')] = items_full["data"].pop(my_key)
-            tmp_list = []
-            tmp_list.append(items_full["data"])
-            items_full["data"] = tmp_list
-        remove_managed_fields(items_full)
+            items_full["data"] = str(items_full["data"])
         output_dict = self._dict
         output_dict['value'] = items_full
         yield output_dict

--- a/transcribe/scribe_modules/k8s_namespaces.py
+++ b/transcribe/scribe_modules/k8s_namespaces.py
@@ -1,7 +1,6 @@
-import json
-
 from . import ScribeModuleBaseClass
-from . lib.k8s_util import remove_managed_fields 
+from . lib.k8s_util import remove_unused_fields
+from . lib.util import dict_to_list
 from transcribe.scribe_modules.lib import util
 
 
@@ -16,7 +15,8 @@ class K8s_namespaces(ScribeModuleBaseClass):
                                        scribe_uuid=scribe_uuid)
 
     def parse(self):
-        remove_managed_fields(self._input_dict)
-        self._dict['value'] = util.fix_nested_dict(self._input_dict)
+        remove_unused_fields(self._input_dict)
+        self._input_dict["metadata"]["annotations"] = dict_to_list(self._input_dict, "metadata", "annotations")
+        self._input_dict["metadata"]["labels"] = dict_to_list(self._input_dict, "metadata", "labels")
+        self._dict['value'] = self._input_dict
         yield self._dict
-

--- a/transcribe/scribe_modules/k8s_nodes.py
+++ b/transcribe/scribe_modules/k8s_nodes.py
@@ -1,6 +1,7 @@
 from . import ScribeModuleBaseClass
-from . lib.util import to_list, validate_length
-from . lib.k8s_util import remove_managed_fields
+from . lib.util import dict_to_list, validate_length
+from . lib.k8s_util import remove_unused_fields
+
 
 class K8s_nodes(ScribeModuleBaseClass):
 
@@ -14,12 +15,11 @@ class K8s_nodes(ScribeModuleBaseClass):
 
     def parse(self):
         nodes_full = self._input_dict
-        # Flatten some of the dictionaries to lists
         validate_length(len(nodes_full), self.module)
+        remove_unused_fields(nodes_full)
         # Flatten some of the dictionaries to lists
-        nodes_full = to_list("metadata","annotations",nodes_full)
-        nodes_full = to_list("metadata","labels",nodes_full)
+        nodes_full["metadata"]["annotations"] = dict_to_list(nodes_full, "metadata", "annotations")
+        nodes_full["metadata"]["labels"] = dict_to_list(nodes_full, "metadata", "labels")
         output_dict = self._dict
-        remove_managed_fields(nodes_full)
         output_dict['value'] = nodes_full
         yield output_dict

--- a/transcribe/scribe_modules/lib/k8s_util.py
+++ b/transcribe/scribe_modules/lib/k8s_util.py
@@ -1,4 +1,6 @@
 
-def remove_managed_fields(d):
+def remove_unused_fields(d):
     if "metadata" in d:
         d["metadata"].pop("managedFields", None)
+    if "metadata" in d and "annotations" in d["metadata"]:
+        d["metadata"]["annotations"].pop("kubectl.kubernetes.io/last-applied-configuration", None)

--- a/transcribe/scribe_modules/lib/util.py
+++ b/transcribe/scribe_modules/lib/util.py
@@ -1,37 +1,22 @@
 import json
 
+
 def format_url(base_url, key):
     return base_url.format(key)
 
-# Currently this function takes two specific levels
-# of depth. However it probably should be expanded
-# to allow for any depth
-def to_list(first_lvl, second_lvl, my_dict):
-    if first_lvl in my_dict:
-        if second_lvl in my_dict[first_lvl]:
-            tmp_list = []
-            tmp_list.append(my_dict[first_lvl][second_lvl])
-            my_dict[first_lvl][second_lvl] = tmp_list
-    return my_dict
+
+def dict_to_list(my_dict, *levels):
+    dict_list = []
+    for lvl in levels:
+        if lvl in my_dict:
+            my_dict = my_dict[lvl]
+        else:
+            return dict_list
+    for k, v in my_dict.items():
+        dict_list.append("%s: %s" % (k, v))
+    return dict_list
 
 
 def validate_length(length, module_name):
     if length <= 1:
         raise ValueError('Error occurred in processing {} data'.format(module_name))
-
-
-def fix_nested_dict(input_dict):
-    # To help with nested dictionaries that are in a format with
-    # escape characters we need to clean it up
-    new_items = json.dumps(input_dict)
-    new_items = new_items.replace('\\n',"")
-    new_items = new_items.replace('\\',"")
-    new_items = new_items.replace(" \"","\"")
-    new_items = new_items.replace(":\"{",": {")
-    new_items = new_items.replace("}\"}","}}")
-    new_items = new_items.replace("}}\"","}}")
-    # Flatten some of the dictionaries to lists
-    new_dict = json.loads(new_items)
-    new_dict = to_list("metadata","annotations", new_dict)
-    new_dict = to_list("metadata","labels", new_dict)
-    return new_dict

--- a/transcribe/scribe_modules/ocp_dns.py
+++ b/transcribe/scribe_modules/ocp_dns.py
@@ -1,4 +1,6 @@
 from . import ScribeModuleBaseClass
+from . lib.util import dict_to_list
+from . lib.k8s_util import remove_unused_fields
 
 
 class Ocp_dns(ScribeModuleBaseClass):
@@ -12,5 +14,8 @@ class Ocp_dns(ScribeModuleBaseClass):
                                        scribe_uuid=scribe_uuid)
 
     def parse(self):
+        remove_unused_fields(self._input_dict)
+        self._input_dict["metadata"]["annotations"] = dict_to_list(self._input_dict, "metadata", "annotations")
+        self._input_dict["metadata"]["labels"] = dict_to_list(self._input_dict, "metadata", "labels")
         self._dict['value'] = self._input_dict
         yield self._dict

--- a/transcribe/scribe_modules/ocp_install_config.py
+++ b/transcribe/scribe_modules/ocp_install_config.py
@@ -1,4 +1,6 @@
 from . import ScribeModuleBaseClass
+from . lib.util import dict_to_list
+from . lib.k8s_util import remove_unused_fields
 
 
 class Ocp_install_config(ScribeModuleBaseClass):
@@ -12,5 +14,8 @@ class Ocp_install_config(ScribeModuleBaseClass):
                                        scribe_uuid=scribe_uuid)
 
     def parse(self):
+        remove_unused_fields(self._input_dict)
+        self._input_dict["metadata"]["annotations"] = dict_to_list(self._input_dict, "metadata", "annotations")
+        self._input_dict["metadata"]["labels"] = dict_to_list(self._input_dict, "metadata", "labels")
         self._dict['value'] = self._input_dict
         yield self._dict

--- a/transcribe/scribe_modules/ocp_net_attachments.py
+++ b/transcribe/scribe_modules/ocp_net_attachments.py
@@ -1,5 +1,7 @@
-from transcribe.scribe_modules.lib import util
 from . import ScribeModuleBaseClass
+from . lib.util import dict_to_list
+from . lib.k8s_util import remove_unused_fields
+
 
 class Ocp_net_attachments(ScribeModuleBaseClass):
 
@@ -12,5 +14,8 @@ class Ocp_net_attachments(ScribeModuleBaseClass):
                                        scribe_uuid=scribe_uuid)
 
     def parse(self):
-        self._dict['value'] = util.fix_nested_dict(self._input_dict)
+        remove_unused_fields(self._input_dict)
+        self._input_dict["metadata"]["annotations"] = dict_to_list(self._input_dict, "metadata", "annotations")
+        self._input_dict["metadata"]["labels"] = dict_to_list(self._input_dict, "metadata", "labels")
+        self._dict['value'] = self._input_dict
         yield self._dict

--- a/transcribe/scribe_modules/ocp_network_operator.py
+++ b/transcribe/scribe_modules/ocp_network_operator.py
@@ -1,4 +1,7 @@
 from . import ScribeModuleBaseClass
+from . lib.util import dict_to_list
+from . lib.k8s_util import remove_unused_fields
+
 
 class Ocp_network_operator(ScribeModuleBaseClass):
 
@@ -11,5 +14,8 @@ class Ocp_network_operator(ScribeModuleBaseClass):
                                        scribe_uuid=scribe_uuid)
 
     def parse(self):
+        remove_unused_fields(self._input_dict)
+        self._input_dict["metadata"]["annotations"] = dict_to_list(self._input_dict, "metadata", "annotations")
+        self._input_dict["metadata"]["labels"] = dict_to_list(self._input_dict, "metadata", "labels")
         self._dict['value'] = self._input_dict
         yield self._dict


### PR DESCRIPTION
With this commit, scribes transform k8s and ocp dictionaries such as annotations, labels and nodeSelector to lists of values. This is required to avoid indexing issues.

These indexing issues are mostly due to the total limit of fields indexed is exceeded in an ES index. The above fields can contain arbitrary keys, so sooner or later this limit will be reached and indexing would start to fail occasionally.

An example document with these transformations would be:

```json
{
  "_index": "k8s_namespaces-metadata",
  "_type": "_doc",
  "_id": "Cj4qtHMBorHmjmbLHlH2",
  "_score": 1,
  "_source": {
    "uuid": "97a7522c-4630-4c30-819b-1a0e108880ea",
    "timestamp": 1596455519,
    "node_name": "Null",
    "pod_name": "Null",
    "module": "k8s_namespaces",
    "host": "localhost",
    "source_type": "stockpile",
    "scribe_uuid": "45047041-40f2-460e-b475-440ff92ac4ea",
    "value": {
      "apiVersion": "v1",
      "kind": "Namespace",
      "metadata": {
        "annotations": [    <-- Here
          "openshift.io/node-selector: ",
          "openshift.io/sa.scc.mcs: s0:c20,c0",
          "openshift.io/sa.scc.supplemental-groups: 1000380000/10000",
          "openshift.io/sa.scc.uid-range: 1000380000/10000"
        ],
        "creationTimestamp": "2020-07-29T15:33:33Z",
        "labels": [    <-- Here
          "olm.operatorgroup.uid/6d5365d1-4c50-4f9b-a8a7-8c7adbf18a7f: ",
          "openshift.io/cluster-monitoring: true",
          "openshift.io/run-level: 0"
        ],
        "name": "openshift-kube-controller-manager",
        "resourceVersion": "22825",
        "selfLink": "/api/v1/namespaces/openshift-kube-controller-manager",
        "uid": "bb7e3edb-4fdc-40b1-a7f0-868fe142caf1"
      },
      "spec": {
        "finalizers": [
          "kubernetes"
        ]
      },
      "status": {
        "phase": "Active"
      }
    }
  },
  "fields": {
    "timestamp": [
      "2020-08-03T11:51:59.000Z"
    ]
  }
}
```

In addition,  it also transform configmap "value" field to string, this is required to prevent ES to index JSON data from configmaps and reaching again the previous limit.

Last and not least, I've updated the remove_unused_fields function to also get rid of "kubectl.kubernetes.io/last-applied-configuration", as this field is useless for our purposes and tends to be very long.