### PR TITLE
Adding k8s_cluster_info to scribe

### DIFF
--- a/transcribe/schema/k8s_cluster_info.yml
+++ b/transcribe/schema/k8s_cluster_info.yml
@@ -1,0 +1,16 @@
+scribe_uuid:
+  type: string
+  required: True
+host:
+  type: string
+  required: True
+module:
+  type: string
+  required: True
+source_type:
+  type: string
+  allowed: ['stockpile','foo']
+  required: True
+value:
+  type: dict
+  required: False

--- a/transcribe/scribe_modules/k8s_cluster_info.py
+++ b/transcribe/scribe_modules/k8s_cluster_info.py
@@ -1,0 +1,23 @@
+from . import ScribeModuleBaseClass
+from . lib.util import dict_to_list, validate_length
+from . lib.k8s_util import remove_unused_fields
+
+
+class K8s_cluster_info(ScribeModuleBaseClass):
+
+    def __init__(self, input_dict=None, module_name=None, host_name=None,
+                 input_type=None, scribe_uuid=None):
+        ScribeModuleBaseClass.__init__(self, module_name=module_name,
+                                       input_dict=input_dict,
+                                       host_name=host_name,
+                                       input_type=input_type,
+                                       scribe_uuid=scribe_uuid)
+
+    def parse(self):
+        cluster_info = self._input_dict
+        validate_length(len(cluster_info), self.module)
+        remove_unused_fields(cluster_info)
+        # Flatten some of the dictionaries to lists
+        output_dict = self._dict
+        output_dict['value'] = cluster_info
+        yield output_dict


### PR DESCRIPTION
Adding scribing of k8s_cluster_info re https://github.com/cloud-bulldozer/stockpile/pull/109

example output:
```
{
    "module": "k8s_cluster_info",
    "host": "localhost",
    "source_type": "stockpile",
    "scribe_uuid": "dfb3c0f9-dfb5-46d8-8089-0036a66a51c2",
    "value": {
        "cluster_name": "scale-65p6n",
        "cluster_version": "4.5.6",
        "kubectl_serverVersion_buildDate": "2020-08-10T05:10:21Z",
        "kubectl_serverVersion_compiler": "gc",
        "kubectl_serverVersion_gitCommit": "002a51f",
        "kubectl_serverVersion_gitTreeState": "clean",
        "kubectl_serverVersion_gitVersion": "v1.18.3+002a51f",
        "kubectl_serverVersion_goVersion": "go1.13.4",
        "kubectl_serverVersion_major": "1",
        "kubectl_serverVersion_minor": "18+",
        "kubectl_serverVersion_platform": "linux/amd64",
        "oc_serverVersion_buildDate": "2020-08-10T05:10:21Z",
        "oc_serverVersion_compiler": "gc",
        "oc_serverVersion_gitCommit": "002a51f",
        "oc_serverVersion_gitTreeState": "clean",
        "oc_serverVersion_gitVersion": "v1.18.3+002a51f",
        "oc_serverVersion_goVersion": "go1.13.4",
        "oc_serverVersion_major": "1",
        "oc_serverVersion_minor": "18+",
        "oc_serverVersion_platform": "linux/amd64",
        "platform": "AWS"
    }
}
```